### PR TITLE
Feature/Add Laravel 12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
 
   test:
-    name: Test (PHP ${{ matrix.php-version }})
+    name: Test (PHP ${{ matrix.php-version }}, Laravel ${{ matrix.laravel-version }})
     runs-on: ubuntu-latest
     needs: [lint]
 
@@ -76,6 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         php-version: ["8.2", "8.3", "8.4"]
+        laravel-version: ["11", "12"]
 
     steps:
       - name: Checkout
@@ -92,17 +93,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: php-${{ matrix.php-version }}-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: php-${{ matrix.php-version }}-composer-
+          key: php-${{ matrix.php-version }}-L${{ matrix.laravel-version }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: php-${{ matrix.php-version }}-L${{ matrix.laravel-version }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          composer require "laravel/framework:^${{ matrix.laravel-version }}.0" --no-update
+          composer install --prefer-dist --no-progress
 
       - name: Run tests
         run: composer test
 
       - name: Upload coverage artifact
-        if: matrix.php-version == '8.4'
+        if: matrix.php-version == '8.4' && matrix.laravel-version == '12'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.2.0",
     "complex-heart/sdk": "^3.0.0",
-    "laravel/framework": "^11.0.0"
+    "laravel/framework": "^11.0.0 || ^12.0.0"
   },
   "require-dev": {
     "pestphp/pest": "*",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require-dev": {
     "pestphp/pest": "*",
-    "pestphp/pest-plugin-faker": "^2.0",
+    "pestphp/pest-plugin-faker": "^2.0 || ^3.0",
     "phpstan/phpstan": "*",
     "mockery/mockery": "^1.6",
     "laravel/pint": "^1.25"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
-  <coverage>
-    <report>
-      <clover outputFile="./coverage.xml"/>
-    </report>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="unit">
       <directory>./tests</directory>


### PR DESCRIPTION
## Summary
- Widen `laravel/framework` constraint to `^11.0.0 || ^12.0.0`
- Add Laravel version dimension to CI test matrix (PHP 8.2/8.3/8.4 × Laravel 11/12 = 6 combos)
- Update `phpunit.xml` XSD to 11.5 and remove deprecated `<coverage>` block (already handled by CLI flags)
- Coverage artifact uploaded only from PHP 8.4 + L12 — SonarCloud receives a single report

## Test plan
- [x] CI passes all 6 matrix combinations
- [x] SonarCloud receives one coverage report (PHP 8.4 + L12)
- [x] `composer install` resolves cleanly with both Laravel 11 and 12