### PR TITLE
Add IlluminateEventBus

### DIFF
--- a/src/Infrastructure/Laravel/ServiceBus/IlluminateEventBus.php
+++ b/src/Infrastructure/Laravel/ServiceBus/IlluminateEventBus.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Infrastructure\Laravel\ServiceBus;
+
+use ComplexHeart\Domain\Contracts\Events\Event;
+use ComplexHeart\Domain\Contracts\Events\EventBus;
+
+/**
+ * Class IlluminateEventBus
+ *
+ * Bridges ComplexHeart's EventBus contract to Laravel's event dispatcher.
+ * Domain events are dispatched through Laravel's event() helper,
+ * which routes listeners by FQCN (fully qualified class name).
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+class IlluminateEventBus implements EventBus
+{
+    /**
+     * Publish domain events through Laravel's event dispatcher.
+     */
+    public function publish(Event ...$events): void
+    {
+        foreach ($events as $event) {
+            event($event);
+        }
+    }
+}

--- a/tests/Unit/IlluminateEventBusTest.php
+++ b/tests/Unit/IlluminateEventBusTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Tests\Unit;
+
+use ComplexHeart\Domain\Contracts\Events\Event;
+use ComplexHeart\Domain\Contracts\Events\EventBus;
+use ComplexHeart\Infrastructure\Laravel\ServiceBus\IlluminateEventBus;
+
+it('should implement the EventBus contract', function () {
+    $bus = new IlluminateEventBus();
+
+    expect($bus)->toBeInstanceOf(EventBus::class);
+});
+
+it('should dispatch events through laravel event helper', function () {
+    $event = \Mockery::mock(Event::class);
+
+    $dispatched = [];
+
+    // Override Laravel's event() helper behavior by registering a
+    // custom event dispatcher in the container.
+    $dispatcher = \Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+    $dispatcher->shouldReceive('dispatch')
+        ->twice()
+        ->andReturnUsing(function ($event) use (&$dispatched) {
+            $dispatched[] = $event;
+        });
+
+    $app = \Illuminate\Container\Container::getInstance();
+    $app->instance('events', $dispatcher);
+
+    $event1 = \Mockery::mock(Event::class);
+    $event2 = \Mockery::mock(Event::class);
+
+    $bus = new IlluminateEventBus();
+    $bus->publish($event1, $event2);
+
+    expect($dispatched)->toHaveCount(2)
+        ->and($dispatched[0])->toBe($event1)
+        ->and($dispatched[1])->toBe($event2);
+});
+
+it('should handle empty events gracefully', function () {
+    $dispatcher = \Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+    $dispatcher->shouldNotReceive('dispatch');
+
+    $app = \Illuminate\Container\Container::getInstance();
+    $app->instance('events', $dispatcher);
+
+    $bus = new IlluminateEventBus();
+    $bus->publish();
+
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- Adds `IlluminateEventBus` implementing ComplexHeart's `EventBus` contract
- Bridges domain events to Laravel's event dispatcher via `event()` helper
- Domain events stay framework-agnostic; this class handles the glue

## Test plan

- [x] Unit tests verify events are dispatched through Laravel's dispatcher
- [x] Empty publish call handled gracefully
- [x] All existing tests still pass (30 total)
- [x] Pint PSR-12 passes