### PR TITLE
Add EloquentFactory base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ composer require complex-heart/on-laravel
 
 - [Bounded Context Service Provider](https://github.com/ComplexHeart/on-laravel/wiki/Bounded-Context-Service-Provider)
 - [Illuminate Event Bus](https://github.com/ComplexHeart/on-laravel/wiki/Illuminate-Event-Bus)
+- [Eloquent Factory](https://github.com/ComplexHeart/on-laravel/wiki/Eloquent-Factory)
 - [Eloquent Criteria Parser](https://github.com/ComplexHeart/on-laravel/wiki/Eloquent-Criteria-Parser)
 - [HTTP Request as Criteria Source](https://github.com/ComplexHeart/on-laravel/wiki/HTTP-Request-as-Criteria-Source)
 

--- a/src/Infrastructure/Laravel/Persistence/EloquentFactory.php
+++ b/src/Infrastructure/Laravel/Persistence/EloquentFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Infrastructure\Laravel\Persistence;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class EloquentFactory
+ *
+ * Abstract factory that bridges Laravel's factory system with ComplexHeart's
+ * domain model construction. When the model provides a static new() factory
+ * method (from IsModel trait), it is used instead of plain instantiation so
+ * that domain invariants are validated during test seeding.
+ *
+ * @template TModel of Model
+ *
+ * @extends Factory<TModel>
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+abstract class EloquentFactory extends Factory
+{
+    public function newModel(array $attributes = [])
+    {
+        $model = $this->modelName();
+
+        return method_exists($model, 'new')
+            ? $model::new(...$attributes)
+            : new $model($attributes);
+    }
+}

--- a/tests/Fixtures/ModelWithNew.php
+++ b/tests/Fixtures/ModelWithNew.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithNew extends Model
+{
+    public bool $createdViaNew = false;
+
+    public string $name = '';
+
+    protected $guarded = [];
+
+    public static function new(string $name = ''): static
+    {
+        $instance = new static();
+        $instance->createdViaNew = true;
+        $instance->name = $name;
+
+        return $instance;
+    }
+}

--- a/tests/Fixtures/ModelWithoutNew.php
+++ b/tests/Fixtures/ModelWithoutNew.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelWithoutNew extends Model
+{
+    public bool $createdViaNew = false;
+
+    protected $guarded = [];
+}

--- a/tests/Unit/EloquentFactoryTest.php
+++ b/tests/Unit/EloquentFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Tests\Unit;
+
+use ComplexHeart\Infrastructure\Laravel\Persistence\EloquentFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+it('should extend Laravel Factory', function () {
+    expect(is_subclass_of(EloquentFactory::class, Factory::class))
+        ->toBeTrue();
+});
+
+it('should use static new() factory when model supports it', function () {
+    $factory = new class () extends EloquentFactory {
+        protected $model = \ComplexHeart\Tests\Fixtures\ModelWithNew::class;
+
+        public function definition(): array
+        {
+            return ['name' => 'test'];
+        }
+    };
+
+    $model = $factory->newModel(['name' => 'hello']);
+
+    expect($model)->toBeInstanceOf(\ComplexHeart\Tests\Fixtures\ModelWithNew::class)
+        ->and($model->createdViaNew)->toBeTrue()
+        ->and($model->name)->toBe('hello');
+});
+
+it('should use plain constructor when model does not have new()', function () {
+    $factory = new class () extends EloquentFactory {
+        protected $model = \ComplexHeart\Tests\Fixtures\ModelWithoutNew::class;
+
+        public function definition(): array
+        {
+            return ['name' => 'test'];
+        }
+    };
+
+    $model = $factory->newModel(['name' => 'hello']);
+
+    expect($model)->toBeInstanceOf(\ComplexHeart\Tests\Fixtures\ModelWithoutNew::class)
+        ->and($model->createdViaNew)->toBeFalse();
+});

--- a/wiki/Eloquent-Factory.md
+++ b/wiki/Eloquent-Factory.md
@@ -1,0 +1,82 @@
+# Eloquent Factory
+
+The `EloquentFactory` bridges Laravel's factory system with ComplexHeart's domain model construction. When a model provides a static `new()` factory method (from the `IsModel` trait), it is used instead of plain instantiation so that domain invariants are validated during test seeding.
+
+## The Problem
+
+Laravel factories use `new Model($attributes)` to create instances, which bypasses ComplexHeart's `Model::new()` static factory. This means domain invariants are not validated during test seeding — factories can create invalid domain objects.
+
+## The Solution
+
+Extend `EloquentFactory` instead of Laravel's `Factory`:
+
+```php
+use ComplexHeart\Infrastructure\Laravel\Persistence\EloquentFactory;
+
+/**
+ * @extends EloquentFactory<User>
+ */
+class UserFactory extends EloquentFactory
+{
+    protected $model = User::class;
+
+    public function definition(): array
+    {
+        return [
+            'id' => $this->faker->uuid(),
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+        ];
+    }
+}
+```
+
+## How It Works
+
+`EloquentFactory` overrides the `newModel()` method:
+
+- If the model has a static `new()` method → uses `Model::new(...$attributes)` (domain construction with invariant validation)
+- If the model does not have `new()` → falls back to `new Model($attributes)` (standard Eloquent construction)
+
+This means you can use `EloquentFactory` for all your models, regardless of whether they use ComplexHeart traits or not.
+
+## Usage
+
+Factories work exactly like standard Laravel factories:
+
+```php
+// Single instance
+$user = User::factory()->create();
+
+// Multiple instances
+$users = User::factory()->count(5)->create();
+
+// With overrides
+$admin = User::factory()->create([
+    'role' => 'admin',
+    'email' => 'admin@example.com',
+]);
+
+// Without persisting
+$user = User::factory()->make();
+```
+
+## Connecting Factory to Model
+
+Add the `HasFactory` trait to your model and point it to your factory:
+
+```php
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use ComplexHeart\Domain\Model\IsAggregate;
+
+class User extends Model implements Aggregate
+{
+    use IsAggregate;
+    use HasFactory;
+
+    protected static function newFactory(): UserFactory
+    {
+        return UserFactory::new();
+    }
+}
+```


### PR DESCRIPTION
Bridges Laravel's factory system with ComplexHeart's domain model construction by using Model::new() when available, ensuring domain invariants are validated during test seeding.