### PR TITLE
Add BoundedContextServiceProvider base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ composer require complex-heart/on-laravel
 
 ## Usage
 
-- [HTTP Request as Criteria Source](https://github.com/ComplexHeart/on-laravel/wiki/HTTP-Request-as-Criteria-Source)
+- [Bounded Context Service Provider](https://github.com/ComplexHeart/on-laravel/wiki/Bounded-Context-Service-Provider)
+- [Illuminate Event Bus](https://github.com/ComplexHeart/on-laravel/wiki/Illuminate-Event-Bus)
 - [Eloquent Criteria Parser](https://github.com/ComplexHeart/on-laravel/wiki/Eloquent-Criteria-Parser)
-
-
+- [HTTP Request as Criteria Source](https://github.com/ComplexHeart/on-laravel/wiki/HTTP-Request-as-Criteria-Source)
 

--- a/src/Infrastructure/Laravel/BoundedContextServiceProvider.php
+++ b/src/Infrastructure/Laravel/BoundedContextServiceProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Infrastructure\Laravel;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Routing\Router;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Class BoundedContextServiceProvider
+ *
+ * Base service provider for bounded contexts in a modular monolith. Each
+ * bounded context should extend this class and declare its own bindings,
+ * event listeners, commands, migrations, and routes.
+ *
+ * @author Unay Santisteban <usantisteban@othercode.io>
+ */
+abstract class BoundedContextServiceProvider extends ServiceProvider
+{
+    /**
+     * Domain event to listener mappings.
+     *
+     * @var array<class-string, class-string|array<class-string>>
+     */
+    protected array $events = [];
+
+    /**
+     * Console commands provided by this context.
+     *
+     * @var array<int, class-string>
+     */
+    protected array $commands = [];
+
+    /**
+     * Migration paths for this context.
+     *
+     * @var array<int, string>
+     */
+    protected array $migrations = [];
+
+    /**
+     * Route definitions grouped by middleware.
+     *
+     * Example:
+     *   ['web' => [__DIR__ . '/Http/Routes/web.php']]
+     *   ['api' => [__DIR__ . '/Http/Routes/api.php']]
+     *
+     * @var array<string, array<int, string>>
+     */
+    protected array $routes = [];
+
+    public function boot(): void
+    {
+        $this->bootMigrations();
+        $this->bootRoutes();
+        $this->bootEvents();
+        $this->bootCommands();
+    }
+
+    protected function bootMigrations(): void
+    {
+        if ($this->migrations !== []) {
+            $this->loadMigrationsFrom($this->migrations);
+        }
+    }
+
+    protected function bootRoutes(): void
+    {
+        /** @var Router $router */
+        $router = $this->app->make('router');
+
+        foreach ($this->routes as $middleware => $files) {
+            foreach ($files as $file) {
+                $router->middleware($middleware)->group($file);
+            }
+        }
+    }
+
+    protected function bootEvents(): void
+    {
+        /** @var Dispatcher $dispatcher */
+        $dispatcher = $this->app->make('events');
+
+        foreach ($this->events as $event => $listeners) {
+            $listeners = is_array($listeners) ? $listeners : [$listeners];
+            foreach ($listeners as $listener) {
+                $dispatcher->listen($event, $listener);
+            }
+        }
+    }
+
+    protected function bootCommands(): void
+    {
+        if ($this->app->runningInConsole() && $this->commands !== []) {
+            $this->commands($this->commands);
+        }
+    }
+}

--- a/tests/Unit/BoundedContextServiceProviderTest.php
+++ b/tests/Unit/BoundedContextServiceProviderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ComplexHeart\Tests\Unit;
+
+use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;
+use Illuminate\Support\ServiceProvider;
+
+function createMockApp(bool $runningInConsole = false): \Mockery\MockInterface
+{
+    $dispatcher = \Mockery::mock(\Illuminate\Contracts\Events\Dispatcher::class);
+    $dispatcher->shouldReceive('listen')->byDefault();
+
+    $router = \Mockery::mock();
+    $router->shouldReceive('middleware')->andReturnSelf()->byDefault();
+    $router->shouldReceive('group')->byDefault();
+
+    $app = \Mockery::mock(\Illuminate\Contracts\Foundation\Application::class, \ArrayAccess::class);
+    $app->shouldReceive('runningInConsole')->andReturn($runningInConsole)->byDefault();
+    $app->shouldReceive('make')->with('events')->andReturn($dispatcher)->byDefault();
+    $app->shouldReceive('make')->with('router')->andReturn($router)->byDefault();
+
+    $app->dispatcher = $dispatcher;
+    $app->router = $router;
+
+    return $app;
+}
+
+it('should extend Laravel ServiceProvider', function () {
+    expect(is_subclass_of(BoundedContextServiceProvider::class, ServiceProvider::class))
+        ->toBeTrue();
+});
+
+it('should register event listeners on boot', function () {
+    $app = createMockApp();
+
+    $app->dispatcher->shouldReceive('listen')
+        ->once()
+        ->with('App\\Events\\OrderPlaced', 'App\\Listeners\\SendConfirmation');
+
+    $provider = new class ($app) extends BoundedContextServiceProvider {
+        protected array $events = [
+            'App\\Events\\OrderPlaced' => 'App\\Listeners\\SendConfirmation',
+        ];
+    };
+
+    $provider->boot();
+});
+
+it('should register multiple listeners for a single event', function () {
+    $app = createMockApp();
+    $app->dispatcher->shouldReceive('listen')->twice();
+
+    $provider = new class ($app) extends BoundedContextServiceProvider {
+        protected array $events = [
+            'App\\Events\\OrderPlaced' => [
+                'App\\Listeners\\SendConfirmation',
+                'App\\Listeners\\UpdateInventory',
+            ],
+        ];
+    };
+
+    $provider->boot();
+});
+
+it('should register console commands when running in console', function () {
+    $app = createMockApp(runningInConsole: true);
+
+    $provider = new class ($app) extends BoundedContextServiceProvider {
+        protected array $commands = [
+            'App\\Console\\SyncCommand',
+        ];
+
+        public function commands($commands): void
+        {
+            $this->testCommands = $commands;
+        }
+
+        public array $testCommands = [];
+    };
+
+    $provider->boot();
+
+    expect($provider->testCommands)->toBe(['App\\Console\\SyncCommand']);
+});
+
+it('should not register commands when not running in console', function () {
+    $app = createMockApp(runningInConsole: false);
+
+    $provider = new class ($app) extends BoundedContextServiceProvider {
+        protected array $commands = [
+            'App\\Console\\SyncCommand',
+        ];
+
+        public function commands($commands): void
+        {
+            $this->testCommands = $commands;
+        }
+
+        public array $testCommands = [];
+    };
+
+    $provider->boot();
+
+    expect($provider->testCommands)->toBe([]);
+});
+
+it('should boot without errors when all arrays are empty', function () {
+    $app = createMockApp();
+
+    $provider = new class ($app) extends BoundedContextServiceProvider {
+    };
+
+    $provider->boot();
+
+    expect(true)->toBeTrue();
+});
+
+it('should load routes grouped by middleware', function () {
+    $app = createMockApp();
+
+    $router = \Mockery::mock();
+    $router->shouldReceive('middleware')->with('web')->once()->andReturnSelf();
+    $router->shouldReceive('middleware')->with('api')->once()->andReturnSelf();
+    $router->shouldReceive('group')->twice();
+
+    $app->shouldReceive('make')->with('router')->andReturn($router);
+
+    $provider = new class ($app) extends BoundedContextServiceProvider {
+        protected array $routes = [
+            'web' => ['/tmp/web.php'],
+            'api' => ['/tmp/api.php'],
+        ];
+    };
+
+    $provider->boot();
+});

--- a/wiki/Bounded-Context-Service-Provider.md
+++ b/wiki/Bounded-Context-Service-Provider.md
@@ -1,0 +1,176 @@
+# Bounded Context Service Provider
+
+The `BoundedContextServiceProvider` is a base class for organizing your Laravel application as a modular monolith. Each bounded context gets its own service provider that declares bindings, event listeners, console commands, migrations, and routes.
+
+## Basic Usage
+
+Extend `BoundedContextServiceProvider` and declare your context's dependencies:
+
+```php
+use ComplexHeart\Infrastructure\Laravel\BoundedContextServiceProvider;
+
+class CompanyRegistryServiceProvider extends BoundedContextServiceProvider
+{
+    public array $bindings = [
+        CompanyRepository::class => EloquentCompanyRepository::class,
+        IndustryRepository::class => EloquentIndustryRepository::class,
+    ];
+
+    protected array $events = [
+        CompanyCreated::class => SendCompanyWelcome::class,
+    ];
+
+    protected array $commands = [
+        SyncCompaniesCommand::class,
+    ];
+
+    protected array $migrations = [
+        __DIR__ . '/Companies/Infrastructure/Persistence/Migrations',
+        __DIR__ . '/Industries/Infrastructure/Persistence/Migrations',
+    ];
+
+    protected array $routes = [
+        'web' => [__DIR__ . '/Shared/Infrastructure/Http/Routes/web.php'],
+        'api' => [__DIR__ . '/Shared/Infrastructure/Http/Routes/api.php'],
+    ];
+}
+```
+
+Register the provider in `bootstrap/app.php` (Laravel 11+) or `config/app.php`:
+
+```php
+// bootstrap/providers.php
+return [
+    App\CompanyRegistry\CompanyRegistryServiceProvider::class,
+    App\IdentityAndAccess\IdentityAndAccessServiceProvider::class,
+];
+```
+
+## Declarative Arrays
+
+### `$bindings`
+
+Standard Laravel `$bindings` — maps interfaces to implementations for this context:
+
+```php
+public array $bindings = [
+    UserRepository::class => EloquentUserRepository::class,
+];
+```
+
+### `$events`
+
+Maps domain events to listeners. Supports a single listener or an array of listeners per event:
+
+```php
+protected array $events = [
+    // Single listener
+    UserCreated::class => SendWelcomeEmail::class,
+
+    // Multiple listeners
+    OrderPlaced::class => [
+        SendOrderConfirmation::class,
+        UpdateInventory::class,
+        NotifyWarehouse::class,
+    ],
+];
+```
+
+### `$commands`
+
+Console commands provided by this context. Only registered when running in console:
+
+```php
+protected array $commands = [
+    SyncUsersCommand::class,
+    PruneExpiredTokensCommand::class,
+];
+```
+
+### `$migrations`
+
+Migration paths for this context:
+
+```php
+protected array $migrations = [
+    __DIR__ . '/Users/Infrastructure/Persistence/Migrations',
+];
+```
+
+### `$routes`
+
+Route files grouped by middleware:
+
+```php
+protected array $routes = [
+    'web' => [__DIR__ . '/Http/Routes/web.php'],
+    'api' => [__DIR__ . '/Http/Routes/api.php'],
+];
+```
+
+## Extending Boot
+
+All boot methods are `protected`, so you can override or extend them:
+
+```php
+class IdentityAndAccessServiceProvider extends BoundedContextServiceProvider
+{
+    protected array $events = [
+        UserEmailUpdated::class => SendEmailVerification::class,
+    ];
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        // Context-specific boot logic
+        $this->configureFortify();
+    }
+
+    private function configureFortify(): void
+    {
+        Fortify::createUsersUsing(CreateUser::class);
+        Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
+    }
+}
+```
+
+## Project Structure
+
+A typical modular monolith using `BoundedContextServiceProvider`:
+
+```
+app/
+├── CompanyRegistry/
+│   ├── CompanyRegistryServiceProvider.php
+│   ├── Companies/
+│   │   ├── Domain/
+│   │   │   ├── Company.php
+│   │   │   ├── Contracts/
+│   │   │   │   └── CompanyRepository.php
+│   │   │   └── Events/
+│   │   │       └── CompanyCreated.php
+│   │   ├── Application/
+│   │   │   └── CreateCompany.php
+│   │   └── Infrastructure/
+│   │       ├── Persistence/
+│   │       │   ├── EloquentCompanyRepository.php
+│   │       │   └── Migrations/
+│   │       └── Http/
+│   │           ├── Controllers/
+│   │           └── Requests/
+│   └── Shared/
+│       └── Infrastructure/
+│           └── Http/
+│               └── Routes/
+│                   ├── web.php
+│                   └── api.php
+├── IdentityAndAccess/
+│   ├── IdentityAndAccessServiceProvider.php
+│   └── Users/
+│       ├── Domain/
+│       ├── Application/
+│       └── Infrastructure/
+```
+
+Each context is self-contained — if you need to extract one into a microservice later, the provider already defines everything it needs.

--- a/wiki/Illuminate-Event-Bus.md
+++ b/wiki/Illuminate-Event-Bus.md
@@ -1,0 +1,142 @@
+# Illuminate Event Bus
+
+The `IlluminateEventBus` bridges ComplexHeart's `EventBus` contract to Laravel's event dispatcher. Domain events are dispatched through Laravel's `event()` helper, which routes listeners by FQCN (fully qualified class name).
+
+## Basic Usage
+
+Bind the `EventBus` contract to `IlluminateEventBus` in your service provider:
+
+```php
+use ComplexHeart\Domain\Contracts\Events\EventBus;
+use ComplexHeart\Infrastructure\Laravel\ServiceBus\IlluminateEventBus;
+
+public array $bindings = [
+    EventBus::class => IlluminateEventBus::class,
+];
+```
+
+## Publishing Domain Events
+
+Domain events are collected by aggregates using the `HasDomainEvents` trait and published through the `EventBus` in use cases:
+
+```php
+final readonly class PlaceOrder
+{
+    public function __construct(
+        private OrderRepository $orders,
+        private EventBus $eventBus,
+    ) {
+    }
+
+    public function __invoke(string $id, string $customerId, float $total): Order
+    {
+        $order = Order::place($id, $customerId, $total);
+        $this->orders->store($order);
+        $order->publishDomainEvents($this->eventBus);
+        return $order;
+    }
+}
+```
+
+## Registering Listeners
+
+Laravel listeners receive the full ComplexHeart `Event` object. Register them using the `$events` array in your `BoundedContextServiceProvider`:
+
+```php
+protected array $events = [
+    OrderPlaced::class => [
+        SendOrderConfirmation::class,
+        UpdateInventory::class,
+    ],
+];
+```
+
+Or register them manually with `Event::listen()`:
+
+```php
+Event::listen(OrderPlaced::class, SendOrderConfirmation::class);
+```
+
+### Listener Example
+
+```php
+class SendOrderConfirmation implements ShouldQueue
+{
+    public function handle(OrderPlaced $event): void
+    {
+        // Access event metadata
+        $eventId = $event->eventId();
+        $eventName = $event->eventName();     // "order.placed"
+        $occurredOn = $event->occurredOn();
+
+        // Access payload directly
+        $orderId = $event->orderId;
+        $customerId = $event->customerId;
+        $total = $event->total;
+
+        // Or as array
+        $payload = $event->payload();
+    }
+}
+```
+
+## How It Works
+
+Laravel's event dispatcher routes events by their FQCN (`get_class($event)`). When `IlluminateEventBus::publish()` is called, it passes each domain event to Laravel's `event()` helper, which dispatches it to any registered listeners.
+
+```
+Aggregate → registerDomainEvent(OrderPlaced::new(...))
+         → publishDomainEvents($eventBus)
+         → IlluminateEventBus::publish(OrderPlaced)
+         → event(OrderPlaced)  // Laravel's event() helper
+         → Laravel dispatches to listeners by FQCN
+```
+
+## Queued Listeners
+
+Domain events carry only primitives (strings, integers, floats, arrays), so PHP's native `serialize()` handles queued listeners without issues. There is no need for Laravel's `SerializesModels` trait on domain events.
+
+```php
+class UpdateInventory implements ShouldQueue
+{
+    public string $queue = 'inventory';
+
+    public function handle(OrderPlaced $event): void
+    {
+        // This runs asynchronously on the 'inventory' queue
+    }
+}
+```
+
+## Broadcasting
+
+Domain events should not implement `ShouldBroadcast` directly — that would couple them to Laravel. Instead, use a bridging listener that creates a Laravel-specific broadcast event:
+
+```php
+// Domain listener bridges to Laravel broadcast
+class BroadcastOrderPlaced implements ShouldQueue
+{
+    public function handle(OrderPlaced $event): void
+    {
+        broadcast(new OrderPlacedBroadcast(
+            orderId: $event->orderId,
+            total: $event->total,
+        ));
+    }
+}
+
+// Laravel broadcast event (infrastructure)
+class OrderPlacedBroadcast implements ShouldBroadcast
+{
+    public function __construct(
+        public readonly string $orderId,
+        public readonly float $total,
+    ) {
+    }
+
+    public function broadcastOn(): array
+    {
+        return [new PrivateChannel("orders.{$this->orderId}")];
+    }
+}
+```


### PR DESCRIPTION
Provides a reusable service provider for modular monolith bounded contexts with declarative event listeners, console commands, migrations, and route registration.